### PR TITLE
Update action.yml

### DIFF
--- a/ApplicationPool.ps1
+++ b/ApplicationPool.ps1
@@ -16,7 +16,7 @@ function __getState {
     )
     $pool = Get-IISAppPool -Name "$AppPoolName"
     $state = $pool.State
-    Write-Host "::set-output name=state::$state"
+    Write-Output "state=$state" >> $ENV:GITHUB_OUTPUT
     Write-Host "IIS application pool $AppPoolName $state"
 }
 
@@ -28,8 +28,8 @@ function __restart {
     $__state = (Get-IISAppPool -Name "$AppPoolName").State
     if ($__state -eq "Stopped") {
         Write-Host "IIS application pool $AppPoolName is in stopped state now. You can't restart stopped application pool"
-        exit 
-    } 
+        exit
+    }
     Restart-WebAppPool -Name "$AppPoolName"
     Write-Host "IIS application pool $AppPoolName restarted."
 }
@@ -51,8 +51,8 @@ function __stop {
     $__state = (Get-IISAppPool -Name "$AppPoolName").State
     if ($__state -eq "Stopped") {
         Write-Host "IIS application pool $AppPoolName already stopped."
-        exit 
-    } 
+        exit
+    }
     $__pid = $true
     $__sleep = 5
     Stop-WebAppPool -Name "$AppPoolName"
@@ -90,19 +90,19 @@ function __checkAppPoolExists {
 function DoAction {
     Param(
         [Parameter(Mandatory = $true)]
-        [string]$Action    
+        [string]$Action
     )
     switch ($Action) {
-        "get-state" { 
+        "get-state" {
             __getState -AppPoolName "$AppPoolName"
          }
-        "restart" { 
+        "restart" {
             __restart -AppPoolName "$AppPoolName"
          }
-        "start" { 
+        "start" {
             __start -AppPoolName "$AppPoolName"
          }
-        "stop" { 
+        "stop" {
             __stop -AppPoolName "$AppPoolName"
          }
     }

--- a/README.md
+++ b/README.md
@@ -5,17 +5,16 @@ Action for self-hosted runners to manipulate iis application pools.
 Required: [IISAdministration](https://learn.microsoft.com/en-us/powershell/module/iisadministration/?view=windowsserver2022-ps)
 
 ## Inputs
-|Parameter|Description|Required|Possible values|
-|---|---|---|---|
-|`action`|The action to run|true|`get-state`, `restart`, `start`, `stop`|
-|`appPoolName`|Name of the target application pool|true (if `siteName` not specified|Any string|
-|`siteName`|Name of the target IIS site|true (if `appPoolName` not specified)|Any string|
+
+| Parameter     | Description                         | Required                              | Possible values                         |
+| ------------- | ----------------------------------- | ------------------------------------- | --------------------------------------- |
+| `action`      | The action to run                   | true                                  | `get-state`, `restart`, `start`, `stop` |
+| `appPoolName` | Name of the target application pool | true (if `siteName` not specified     | Any string                              |
+| `siteName`    | Name of the target IIS site         | true (if `appPoolName` not specified) | Any string                              |
 
 ## Examples
 
 ```yaml
-...
-
 jobs:
   example:
     runs-on: [self-hosted, deploy]
@@ -26,14 +25,11 @@ jobs:
         with:
           action: start
           siteName: "Default Web Site"
-      - run: Write-Host "App pool for the Default Web Site ${{ steps.start_app_pool.outputs.state }}" 
-
-...
+          appPoolName:
+      - run: Write-Host "App pool for the Default Web Site ${{ steps.start_app_pool.outputs.state }}"
 ```
 
 ```yaml
-...
-
 jobs:
   example:
     runs-on: [self-hosted, deploy]
@@ -43,8 +39,7 @@ jobs:
         uses: 1k-off/iis-apppool-action@1.0.0
         with:
           action: start
+          siteName:
           appPoolName: "Default Web Site"
-      - run: Write-Host "App pool for the Default Web Site ${{ steps.start_app_pool.outputs.state }}" 
-
-...
+      - run: Write-Host "App pool for the Default Web Site ${{ steps.start_app_pool.outputs.state }}"
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Required: [IISAdministration](https://learn.microsoft.com/en-us/powershell/modul
 ## Examples
 
 ```yaml
+...
 jobs:
   example:
     runs-on: [self-hosted, deploy]
@@ -27,9 +28,11 @@ jobs:
           siteName: "Default Web Site"
           appPoolName:
       - run: Write-Host "App pool for the Default Web Site ${{ steps.start_app_pool.outputs.state }}"
+...
 ```
 
 ```yaml
+...
 jobs:
   example:
     runs-on: [self-hosted, deploy]
@@ -42,4 +45,5 @@ jobs:
           siteName:
           appPoolName: "Default Web Site"
       - run: Write-Host "App pool for the Default Web Site ${{ steps.start_app_pool.outputs.state }}"
+...
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'IIS Application Pool Action'
+name: IIS Application Pool Action
 
-description: 'This action can restart, start or stop an IIS application pool, or get information about its state.'
+description: This action can restart, start or stop an IIS application pool, or get information about its state.
 
 inputs:
   action:
@@ -13,20 +13,20 @@ inputs:
       - stop
     required: true
   appPoolName:
-    description: 'IIS application pool name'
+    description: IIS application pool name
     required: true
   siteName:
-    description: 'IIS site name'
+    description: IIS site name
     required: true
 outputs:
   appPoolName:
-    description: "Application pool name"
+    description: Application pool name
     value: ${{ steps.iis_application_pool.outputs.appPoolName }}
   state:
-    description: "Application pool state"
+    description: Application pool state
     value: ${{ steps.iis_application_pool.outputs.state }}
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - name: Set IIS app pool name
       id: set_app_pool_name

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,12 @@ description: 'This action can restart, start or stop an IIS application pool, or
 inputs:
   action:
     description: Specify get-state, restart, start, stop as the action to perform
+    type: choice
+    options:
+      - get-state
+      - restart
+      - start
+      - stop
     required: true
   appPoolName:
     description: 'IIS application pool name'
@@ -13,6 +19,9 @@ inputs:
     description: 'IIS site name'
     required: true
 outputs:
+  appPoolName:
+    description: "Application pool name"
+    value: ${{ steps.iis_application_pool.outputs.appPoolName }}
   state:
     description: "Application pool state"
     value: ${{ steps.iis_application_pool.outputs.state }}
@@ -24,7 +33,7 @@ runs:
       shell: powershell
       run: |
         if ("${{ inputs.appPoolName }}" -ne ""){
-          Write-Host "::set-output name=appPoolName::${{ inputs.appPoolName }}"
+          Write-Output "appPoolName=${{ inputs.appPoolName }}" >> $ENV:GITHUB_OUTPUT
         } elseif ("${{ inputs.appPoolName }}" -eq "" -And "${{ inputs.siteName }}" -ne "") {
           $s = Get-IISSite -Name "${{ inputs.siteName }}" -WarningAction:SilentlyContinue
           if ($null -eq "$s") {
@@ -32,7 +41,7 @@ runs:
             exit 1
           }
           $p = ((Get-IISSite -Name "${{ inputs.siteName }}").Applications | Where-Object {$_.Path -eq "/" }).ApplicationPoolName
-          Write-Host "::set-output name=appPoolName::$p"
+          Write-Output "appPoolName=$p" >> $ENV:GITHUB_OUTPUT
         } else {
           Write-Host "You should fill one of these variables: 'appPoolName' or 'siteName'."
         }


### PR DESCRIPTION
- Fix the `Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/`message
- Gives options to the action input